### PR TITLE
feat(video): implement video service and handler with related models

### DIFF
--- a/src/Videos/IVideoHandler.cs
+++ b/src/Videos/IVideoHandler.cs
@@ -1,0 +1,39 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public interface IVideoHandler : IYouTubeHandler
+{
+    Task<YouTubeResult<VideoListResponse>> HandleVideoListAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken);
+
+    Task<YouTubeResult<VideoResource>> HandleVideoInsertAsync(
+        VideoResource resource,
+        StreamContent? content,
+        VideoProperties properties,
+        CancellationToken cancellationToken);
+
+    Task<YouTubeResult<VideoResource>> HandleVideoUpdateAsync(
+        VideoResource resource,
+        StreamContent? content,
+        VideoProperties properties,
+        CancellationToken cancellationToken);
+
+    Task<YouTubeResult> HandleVideoDeleteAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken);
+
+    Task<YouTubeResult> HandleVideoRateAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken);
+
+    Task<YouTubeResult<VideoGetRatingResponse>> HandleVideoGetRatingAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken);
+
+    Task<YouTubeResult> HandleVideoReportAbuseAsync(
+        VideoReportAbuseRequest resource,
+        VideoProperties properties,
+        CancellationToken cancellationToken);
+}

--- a/src/Videos/IVideosService.cs
+++ b/src/Videos/IVideosService.cs
@@ -1,0 +1,82 @@
+// Licensed under the MIT license by loonfactory.
+
+using Microsoft.Extensions.Primitives;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public interface IVideosService
+{
+    Task<VideoListResponse> ListByIdAsync(
+        StringValues part,
+        StringValues id,
+        uint? maxResults = null,
+        string? pageToken = null,
+        string? hl = null,
+        string? regionCode = null,
+        string? videoCategoryId = null,
+        uint? maxHeight = null,
+        uint? maxWidth = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default);
+
+    Task<VideoListResponse> ListByChartAsync(
+        StringValues part,
+        string chart,
+        uint? maxResults = null,
+        string? pageToken = null,
+        string? hl = null,
+        string? regionCode = null,
+        string? videoCategoryId = null,
+        uint? maxHeight = null,
+        uint? maxWidth = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default);
+
+    Task<VideoListResponse> ListByMyRatingAsync(
+        StringValues part,
+        string myRating,
+        uint? maxResults = null,
+        string? pageToken = null,
+        string? hl = null,
+        uint? maxHeight = null,
+        uint? maxWidth = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default);
+
+    Task<VideoResource> InsertAsync(
+        StringValues part,
+        VideoResource resource,
+        StreamContent? content = null,
+        bool? autoLevels = null,
+        bool? notifySubscribers = null,
+        string? onBehalfOfContentOwner = null,
+        string? onBehalfOfContentOwnerChannel = null,
+        CancellationToken cancellationToken = default);
+
+    Task<VideoResource> UpdateAsync(
+        StringValues part,
+        VideoResource resource,
+        StreamContent? content = null,
+        bool? notifySubscribers = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(
+        StringValues id,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default);
+
+    Task RateAsync(
+        StringValues id,
+        string rating,
+        CancellationToken cancellationToken = default);
+
+    Task<VideoGetRatingResponse> GetRatingAsync(
+        StringValues id,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default);
+
+    Task ReportAbuseAsync(
+        VideoReportAbuseRequest resource,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Videos/VideoContentDetails.cs
+++ b/src/Videos/VideoContentDetails.cs
@@ -8,6 +8,7 @@ public class VideoContentDetails
     public string? Dimension { get; set; }
     public string? Definition { get; set; }
     public string? Caption { get; set; }
+    public VideoContentRating? ContentRating { get; set; }
     public bool? LicensedContent { get; set; }
     public string? Projection { get; set; }
 }

--- a/src/Videos/VideoContentDetails.cs
+++ b/src/Videos/VideoContentDetails.cs
@@ -10,5 +10,7 @@ public class VideoContentDetails
     public string? Caption { get; set; }
     public VideoContentRating? ContentRating { get; set; }
     public bool? LicensedContent { get; set; }
+    public VideoRegionRestriction? RegionRestriction { get; set; }
     public string? Projection { get; set; }
+    public bool? HasCustomThumbnail { get; set; }
 }

--- a/src/Videos/VideoContentDetails.cs
+++ b/src/Videos/VideoContentDetails.cs
@@ -1,0 +1,13 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoContentDetails
+{
+    public string? Duration { get; set; }
+    public string? Dimension { get; set; }
+    public string? Definition { get; set; }
+    public string? Caption { get; set; }
+    public bool? LicensedContent { get; set; }
+    public string? Projection { get; set; }
+}

--- a/src/Videos/VideoContentRating.cs
+++ b/src/Videos/VideoContentRating.cs
@@ -24,6 +24,7 @@ public class VideoContentRating
     public string? CscfRating { get; set; }
     public string? CzfilmRating { get; set; }
     public string? DjctqRating { get; set; }
+    public IEnumerable<string>? DjctqRatingReasons { get; set; }
     public string? EcbmctRating { get; set; }
     public string? EefilmRating { get; set; }
     public string? EgfilmRating { get; set; }
@@ -48,7 +49,7 @@ public class VideoContentRating
     public string? McstRating { get; set; }
     public string? MdaRating { get; set; }
     public string? MedietilsynetRating { get; set; }
-    public string? MeusRating { get; set; }
+    public string? MekuRating { get; set; }
     public string? MibacRating { get; set; }
     public string? MocRating { get; set; }
     public string? MoctwRating { get; set; }

--- a/src/Videos/VideoContentRating.cs
+++ b/src/Videos/VideoContentRating.cs
@@ -1,0 +1,75 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoContentRating
+{
+    public string? AcbRating { get; set; }
+    public string? AgcomRating { get; set; }
+    public string? AnatelRating { get; set; }
+    public string? BbfcRating { get; set; }
+    public string? BfvcRating { get; set; }
+    public string? BmukkRating { get; set; }
+    public string? CatvRating { get; set; }
+    public string? CatvfrRating { get; set; }
+    public string? CbfcRating { get; set; }
+    public string? CccRating { get; set; }
+    public string? CceRating { get; set; }
+    public string? ChfilmRating { get; set; }
+    public string? ChvrsRating { get; set; }
+    public string? CicfRating { get; set; }
+    public string? CnaRating { get; set; }
+    public string? CncRating { get; set; }
+    public string? CsaRating { get; set; }
+    public string? CscfRating { get; set; }
+    public string? CzfilmRating { get; set; }
+    public string? DjctqRating { get; set; }
+    public string? EcbmctRating { get; set; }
+    public string? EefilmRating { get; set; }
+    public string? EgfilmRating { get; set; }
+    public string? EirinRating { get; set; }
+    public string? FcbmRating { get; set; }
+    public string? FcoRating { get; set; }
+    public string? FmocRating { get; set; }
+    public string? FpbRating { get; set; }
+    public IEnumerable<string>? FpbRatingReasons { get; set; }
+    public string? FskRating { get; set; }
+    public string? GrfilmRating { get; set; }
+    public string? IcaaRating { get; set; }
+    public string? IfcoRating { get; set; }
+    public string? IlfilmRating { get; set; }
+    public string? IncaaRating { get; set; }
+    public string? KfcbRating { get; set; }
+    public string? KijkwijzerRating { get; set; }
+    public string? KmrbRating { get; set; }
+    public string? LsfRating { get; set; }
+    public string? MccaaRating { get; set; }
+    public string? MccypRating { get; set; }
+    public string? McstRating { get; set; }
+    public string? MdaRating { get; set; }
+    public string? MedietilsynetRating { get; set; }
+    public string? MeusRating { get; set; }
+    public string? MibacRating { get; set; }
+    public string? MocRating { get; set; }
+    public string? MoctwRating { get; set; }
+    public string? MpaaRating { get; set; }
+    public string? MpaatRating { get; set; }
+    public string? MtrcbRating { get; set; }
+    public string? NbcRating { get; set; }
+    public string? NbcplRating { get; set; }
+    public string? NfrcRating { get; set; }
+    public string? NfvcbRating { get; set; }
+    public string? NkclvRating { get; set; }
+    public string? OflcRating { get; set; }
+    public string? PefilmRating { get; set; }
+    public string? RcnofRating { get; set; }
+    public string? ResorteviolenciaRating { get; set; }
+    public string? RtcRating { get; set; }
+    public string? RteRating { get; set; }
+    public string? RussiaRating { get; set; }
+    public string? SkfilmRating { get; set; }
+    public string? SmaisRating { get; set; }
+    public string? SmsaRating { get; set; }
+    public string? TvpgRating { get; set; }
+    public string? YtRating { get; set; }
+}

--- a/src/Videos/VideoDefaults.cs
+++ b/src/Videos/VideoDefaults.cs
@@ -1,0 +1,17 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public static class VideoDefaults
+{
+    private const string ApiRootUrl = "https://www.googleapis.com/youtube/v3";
+    private const string UploadRootUrl = "https://www.googleapis.com/upload/youtube/v3";
+
+    public static readonly string ListEndpoint = $"{ApiRootUrl}/videos";
+    public static readonly string InsertEndpoint = $"{UploadRootUrl}/videos";
+    public static readonly string UpdateEndpoint = $"{UploadRootUrl}/videos";
+    public static readonly string DeleteEndpoint = $"{ApiRootUrl}/videos";
+    public static readonly string RateEndpoint = $"{ApiRootUrl}/videos/rate";
+    public static readonly string GetRatingEndpoint = $"{ApiRootUrl}/videos/getRating";
+    public static readonly string ReportAbuseEndpoint = $"{ApiRootUrl}/videos/reportAbuse";
+}

--- a/src/Videos/VideoFileDetails.cs
+++ b/src/Videos/VideoFileDetails.cs
@@ -1,0 +1,16 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoFileDetails
+{
+    public string? FileName { get; set; }
+    public ulong? FileSize { get; set; }
+    public string? FileType { get; set; }
+    public string? Container { get; set; }
+    public IEnumerable<VideoFileDetailsVideoStream>? VideoStreams { get; set; }
+    public IEnumerable<VideoFileDetailsAudioStream>? AudioStreams { get; set; }
+    public ulong? DurationMs { get; set; }
+    public ulong? BitrateBps { get; set; }
+    public string? CreationTime { get; set; }
+}

--- a/src/Videos/VideoFileDetailsAudioStream.cs
+++ b/src/Videos/VideoFileDetailsAudioStream.cs
@@ -1,0 +1,11 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoFileDetailsAudioStream
+{
+    public uint? ChannelCount { get; set; }
+    public string? Codec { get; set; }
+    public ulong? BitrateBps { get; set; }
+    public string? Vendor { get; set; }
+}

--- a/src/Videos/VideoFileDetailsVideoStream.cs
+++ b/src/Videos/VideoFileDetailsVideoStream.cs
@@ -1,0 +1,15 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoFileDetailsVideoStream
+{
+    public uint? WidthPixels { get; set; }
+    public uint? HeightPixels { get; set; }
+    public double? FrameRateFps { get; set; }
+    public double? AspectRatio { get; set; }
+    public string? Codec { get; set; }
+    public ulong? BitrateBps { get; set; }
+    public string? Rotation { get; set; }
+    public string? Vendor { get; set; }
+}

--- a/src/Videos/VideoGetRatingResponse.cs
+++ b/src/Videos/VideoGetRatingResponse.cs
@@ -1,0 +1,15 @@
+// Licensed under the MIT license by loonfactory.
+
+using System.Text.Json.Serialization;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoGetRatingResponse
+{
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("etag")]
+    public string? ETag { get; set; }
+
+    public IEnumerable<VideoRating>? Items { get; set; }
+}

--- a/src/Videos/VideoHandler.cs
+++ b/src/Videos/VideoHandler.cs
@@ -1,0 +1,234 @@
+// Licensed under the MIT license by loonfactory.
+
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoHandler(
+    IOptionsMonitor<YouTubeOptions> options,
+    ILoggerFactory logger
+) : YouTubeHandler(options, logger), IVideoHandler
+{
+    public virtual async Task<YouTubeResult<VideoListResponse>> HandleVideoListAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+
+        if (StringValues.IsNullOrEmpty(properties.Part))
+        {
+            throw new InvalidOperationException("The part parameter must be provided in the properties.");
+        }
+
+        var filterCount = 0;
+        if (!StringValues.IsNullOrEmpty(properties.Id))
+        {
+            filterCount++;
+        }
+
+        if (!string.IsNullOrWhiteSpace(properties.Chart))
+        {
+            filterCount++;
+        }
+
+        if (!string.IsNullOrWhiteSpace(properties.MyRating))
+        {
+            filterCount++;
+        }
+
+        if (filterCount != 1)
+        {
+            throw new InvalidOperationException("Exactly one of id, chart, or myRating must be provided.");
+        }
+
+        using var response = await SendAsync(
+            HttpMethod.Get,
+            VideoDefaults.ListEndpoint,
+            properties,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new NotImplementedException("Handling of unsuccessful HTTP responses is not yet implemented.");
+        }
+
+        return YouTubeResult<VideoListResponse>.Success(
+            (await response.Content.ReadFromJsonAsync<VideoListResponse>(
+                YouTubeDefaults.JsonSerializerOptions,
+                cancellationToken
+            ).ConfigureAwait(false))!
+        );
+    }
+
+    public virtual Task<YouTubeResult<VideoResource>> HandleVideoInsertAsync(
+        VideoResource resource,
+        StreamContent? content,
+        VideoProperties properties,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(properties);
+        ArgumentNullException.ThrowIfNull(cancellationToken);
+
+        if (StringValues.IsNullOrEmpty(properties.Part))
+        {
+            throw new InvalidOperationException("The part parameter must be provided in the properties.");
+        }
+
+        var endpoint = BuildChallengeUrl(VideoDefaults.InsertEndpoint, properties);
+        var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+        return UploadAsync(request, resource, content, properties, cancellationToken);
+    }
+
+    public virtual Task<YouTubeResult<VideoResource>> HandleVideoUpdateAsync(
+        VideoResource resource,
+        StreamContent? content,
+        VideoProperties properties,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(properties);
+        ArgumentNullException.ThrowIfNull(cancellationToken);
+
+        if (StringValues.IsNullOrEmpty(properties.Part))
+        {
+            throw new InvalidOperationException("The part parameter must be provided in the properties.");
+        }
+
+        if (string.IsNullOrEmpty(resource.Id))
+        {
+            throw new InvalidOperationException("The video id must be set on the resource.");
+        }
+
+        var endpoint = BuildChallengeUrl(VideoDefaults.UpdateEndpoint, properties);
+        var request = new HttpRequestMessage(HttpMethod.Put, endpoint);
+        return UploadAsync(request, resource, content, properties, cancellationToken);
+    }
+
+    public virtual async Task<YouTubeResult> HandleVideoDeleteAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+
+        if (StringValues.IsNullOrEmpty(properties.Id))
+        {
+            throw new InvalidOperationException("The video id must be provided in the properties.");
+        }
+
+        using var response = await AuthorizationSendAsync(
+            HttpMethod.Delete,
+            VideoDefaults.DeleteEndpoint,
+            properties,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        return response.IsSuccessStatusCode switch
+        {
+            true => YouTubeResult.NoResult,
+            false => throw new NotImplementedException("Handling of unsuccessful HTTP responses is not yet implemented.")
+        };
+    }
+
+    public virtual async Task<YouTubeResult> HandleVideoRateAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+
+        if (StringValues.IsNullOrEmpty(properties.Id))
+        {
+            throw new InvalidOperationException("The video id must be provided in the properties.");
+        }
+
+        if (string.IsNullOrWhiteSpace(properties.Rating))
+        {
+            throw new InvalidOperationException("The rating parameter must be provided in the properties.");
+        }
+
+        using var response = await AuthorizationSendAsync(
+            HttpMethod.Post,
+            VideoDefaults.RateEndpoint,
+            properties,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        return response.IsSuccessStatusCode switch
+        {
+            true => YouTubeResult.NoResult,
+            false => throw new NotImplementedException("Handling of unsuccessful HTTP responses is not yet implemented.")
+        };
+    }
+
+    public virtual async Task<YouTubeResult<VideoGetRatingResponse>> HandleVideoGetRatingAsync(
+        VideoProperties properties,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+
+        if (StringValues.IsNullOrEmpty(properties.Id))
+        {
+            throw new InvalidOperationException("The video id must be provided in the properties.");
+        }
+
+        using var response = await AuthorizationSendAsync(
+            HttpMethod.Get,
+            VideoDefaults.GetRatingEndpoint,
+            properties,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new NotImplementedException("Handling of unsuccessful HTTP responses is not yet implemented.");
+        }
+
+        return YouTubeResult<VideoGetRatingResponse>.Success(
+            (await response.Content.ReadFromJsonAsync<VideoGetRatingResponse>(
+                YouTubeDefaults.JsonSerializerOptions,
+                cancellationToken
+            ).ConfigureAwait(false))!
+        );
+    }
+
+    public virtual async Task<YouTubeResult> HandleVideoReportAbuseAsync(
+        VideoReportAbuseRequest resource,
+        VideoProperties properties,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(properties);
+
+        if (string.IsNullOrWhiteSpace(resource.VideoId))
+        {
+            throw new InvalidOperationException("The resource.VideoId must be provided.");
+        }
+
+        if (string.IsNullOrWhiteSpace(resource.ReasonId))
+        {
+            throw new InvalidOperationException("The resource.ReasonId must be provided.");
+        }
+
+        var endpoint = BuildChallengeUrl(VideoDefaults.ReportAbuseEndpoint, properties);
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = JsonContent.Create(resource)
+        };
+
+        using var response = await AuthorizationSendAsync(
+            request,
+            properties,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        return response.IsSuccessStatusCode switch
+        {
+            true => YouTubeResult.NoResult,
+            false => throw new NotImplementedException("Handling of unsuccessful HTTP responses is not yet implemented.")
+        };
+    }
+}

--- a/src/Videos/VideoHandler.cs
+++ b/src/Videos/VideoHandler.cs
@@ -79,6 +79,8 @@ public class VideoHandler(
             throw new InvalidOperationException("The part parameter must be provided in the properties.");
         }
 
+        ThrowIfAccessTokenNullOrEmpty(properties.AccessToken);
+
         var endpoint = BuildChallengeUrl(VideoDefaults.InsertEndpoint, properties);
         var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
         return UploadAsync(request, resource, content, properties, cancellationToken);
@@ -103,6 +105,8 @@ public class VideoHandler(
         {
             throw new InvalidOperationException("The video id must be set on the resource.");
         }
+
+        ThrowIfAccessTokenNullOrEmpty(properties.AccessToken);
 
         var endpoint = BuildChallengeUrl(VideoDefaults.UpdateEndpoint, properties);
         var request = new HttpRequestMessage(HttpMethod.Put, endpoint);

--- a/src/Videos/VideoHandler.cs
+++ b/src/Videos/VideoHandler.cs
@@ -41,7 +41,7 @@ public class VideoHandler(
 
         if (filterCount != 1)
         {
-            throw new InvalidOperationException("Exactly one of id, chart, or myRating must be provided.");
+            throw new InvalidOperationException("Filters (specify exactly one of the following parameters): id, chart, myRating.");
         }
 
         using var response = await SendAsync(

--- a/src/Videos/VideoListResponse.cs
+++ b/src/Videos/VideoListResponse.cs
@@ -1,0 +1,18 @@
+// Licensed under the MIT license by loonfactory.
+
+using System.Text.Json.Serialization;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoListResponse
+{
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("etag")]
+    public string? ETag { get; set; }
+
+    public string? NextPageToken { get; set; }
+    public string? PrevPageToken { get; set; }
+    public YouTubePageInfo? PageInfo { get; set; }
+    public IEnumerable<VideoResource>? Items { get; set; }
+}

--- a/src/Videos/VideoLiveStreamingDetails.cs
+++ b/src/Videos/VideoLiveStreamingDetails.cs
@@ -1,0 +1,13 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoLiveStreamingDetails
+{
+    public DateTimeOffset? ActualStartTime { get; set; }
+    public DateTimeOffset? ActualEndTime { get; set; }
+    public DateTimeOffset? ScheduledStartTime { get; set; }
+    public DateTimeOffset? ScheduledEndTime { get; set; }
+    public ulong? ConcurrentViewers { get; set; }
+    public string? ActiveLiveChatId { get; set; }
+}

--- a/src/Videos/VideoPaidProductPlacementDetails.cs
+++ b/src/Videos/VideoPaidProductPlacementDetails.cs
@@ -1,0 +1,8 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoPaidProductPlacementDetails
+{
+    public bool? HasPaidProductPlacement { get; set; }
+}

--- a/src/Videos/VideoPlayer.cs
+++ b/src/Videos/VideoPlayer.cs
@@ -1,0 +1,10 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoPlayer
+{
+    public string? EmbedHtml { get; set; }
+    public long? EmbedHeight { get; set; }
+    public long? EmbedWidth { get; set; }
+}

--- a/src/Videos/VideoProcessingDetails.cs
+++ b/src/Videos/VideoProcessingDetails.cs
@@ -1,0 +1,15 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoProcessingDetails
+{
+    public string? ProcessingStatus { get; set; }
+    public VideoProcessingProgress? ProcessingProgress { get; set; }
+    public string? ProcessingFailureReason { get; set; }
+    public string? FileDetailsAvailability { get; set; }
+    public string? ProcessingIssuesAvailability { get; set; }
+    public string? TagSuggestionsAvailability { get; set; }
+    public string? EditorSuggestionsAvailability { get; set; }
+    public string? ThumbnailsAvailability { get; set; }
+}

--- a/src/Videos/VideoProcessingProgress.cs
+++ b/src/Videos/VideoProcessingProgress.cs
@@ -1,0 +1,10 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoProcessingProgress
+{
+    public ulong? PartsTotal { get; set; }
+    public ulong? PartsProcessed { get; set; }
+    public ulong? TimeLeftMs { get; set; }
+}

--- a/src/Videos/VideoProperties.cs
+++ b/src/Videos/VideoProperties.cs
@@ -1,0 +1,132 @@
+// Licensed under the MIT license by loonfactory.
+
+using Microsoft.Extensions.Primitives;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoProperties : YouTubeProperties
+{
+    public static readonly string PartKey = "part";
+    public static readonly string ChartKey = "chart";
+    public static readonly string HlKey = "hl";
+    public static readonly string IdKey = "id";
+    public static readonly string MaxHeightKey = "maxHeight";
+    public static readonly string MaxResultsKey = "maxResults";
+    public static readonly string MaxWidthKey = "maxWidth";
+    public static readonly string MyRatingKey = "myRating";
+    public static readonly string OnBehalfOfContentOwnerKey = "onBehalfOfContentOwner";
+    public static readonly string OnBehalfOfContentOwnerChannelKey = "onBehalfOfContentOwnerChannel";
+    public static readonly string PageTokenKey = "pageToken";
+    public static readonly string RegionCodeKey = "regionCode";
+    public static readonly string VideoCategoryIdKey = "videoCategoryId";
+    public static readonly string AutoLevelsKey = "autoLevels";
+    public static readonly string NotifySubscribersKey = "notifySubscribers";
+    public static readonly string RatingKey = "rating";
+
+    public VideoProperties()
+    { }
+
+    public VideoProperties(IDictionary<string, string?> items)
+        : base(items)
+    { }
+
+    public VideoProperties(IDictionary<string, string?> items, IDictionary<string, object?> parameters)
+        : base(items, parameters)
+    { }
+
+    public StringValues Part
+    {
+        get => GetParameter<StringValues>(PartKey);
+        set => SetParameter(PartKey, value);
+    }
+
+    public string? Chart
+    {
+        get => GetParameter<string>(ChartKey);
+        set => SetParameter(ChartKey, value);
+    }
+
+    public string? Hl
+    {
+        get => GetParameter<string>(HlKey);
+        set => SetParameter(HlKey, value);
+    }
+
+    public StringValues Id
+    {
+        get => GetParameter<StringValues>(IdKey);
+        set => SetParameter(IdKey, value);
+    }
+
+    public uint? MaxHeight
+    {
+        get => GetParameter<uint?>(MaxHeightKey);
+        set => SetParameter(MaxHeightKey, value);
+    }
+
+    public uint? MaxResults
+    {
+        get => GetParameter<uint?>(MaxResultsKey);
+        set => SetParameter(MaxResultsKey, value);
+    }
+
+    public uint? MaxWidth
+    {
+        get => GetParameter<uint?>(MaxWidthKey);
+        set => SetParameter(MaxWidthKey, value);
+    }
+
+    public string? MyRating
+    {
+        get => GetParameter<string>(MyRatingKey);
+        set => SetParameter(MyRatingKey, value);
+    }
+
+    public string? OnBehalfOfContentOwner
+    {
+        get => GetParameter<string>(OnBehalfOfContentOwnerKey);
+        set => SetParameter(OnBehalfOfContentOwnerKey, value);
+    }
+
+    public string? OnBehalfOfContentOwnerChannel
+    {
+        get => GetParameter<string>(OnBehalfOfContentOwnerChannelKey);
+        set => SetParameter(OnBehalfOfContentOwnerChannelKey, value);
+    }
+
+    public string? PageToken
+    {
+        get => GetParameter<string>(PageTokenKey);
+        set => SetParameter(PageTokenKey, value);
+    }
+
+    public string? RegionCode
+    {
+        get => GetParameter<string>(RegionCodeKey);
+        set => SetParameter(RegionCodeKey, value);
+    }
+
+    public string? VideoCategoryId
+    {
+        get => GetParameter<string>(VideoCategoryIdKey);
+        set => SetParameter(VideoCategoryIdKey, value);
+    }
+
+    public bool? AutoLevels
+    {
+        get => GetParameter<bool?>(AutoLevelsKey);
+        set => SetParameter(AutoLevelsKey, value);
+    }
+
+    public bool? NotifySubscribers
+    {
+        get => GetParameter<bool?>(NotifySubscribersKey);
+        set => SetParameter(NotifySubscribersKey, value);
+    }
+
+    public string? Rating
+    {
+        get => GetParameter<string>(RatingKey);
+        set => SetParameter(RatingKey, value);
+    }
+}

--- a/src/Videos/VideoRating.cs
+++ b/src/Videos/VideoRating.cs
@@ -1,0 +1,9 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoRating
+{
+    public string? VideoId { get; set; }
+    public string? Rating { get; set; }
+}

--- a/src/Videos/VideoRecordingDetails.cs
+++ b/src/Videos/VideoRecordingDetails.cs
@@ -1,0 +1,8 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoRecordingDetails
+{
+    public DateTimeOffset? RecordingDate { get; set; }
+}

--- a/src/Videos/VideoRegionRestriction.cs
+++ b/src/Videos/VideoRegionRestriction.cs
@@ -1,0 +1,9 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoRegionRestriction
+{
+    public IEnumerable<string>? Allowed { get; set; }
+    public IEnumerable<string>? Blocked { get; set; }
+}

--- a/src/Videos/VideoReportAbuseRequest.cs
+++ b/src/Videos/VideoReportAbuseRequest.cs
@@ -1,0 +1,10 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoReportAbuseRequest
+{
+    public string? VideoId { get; set; }
+    public string? ReasonId { get; set; }
+    public string? SecondaryReasonId { get; set; }
+}

--- a/src/Videos/VideoResource.cs
+++ b/src/Videos/VideoResource.cs
@@ -1,0 +1,22 @@
+// Licensed under the MIT license by loonfactory.
+
+using System.Text.Json.Serialization;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoResource
+{
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("etag")]
+    public string? ETag { get; set; }
+
+    public string? Id { get; set; }
+    public VideoSnippet? Snippet { get; set; }
+    public VideoStatus? Status { get; set; }
+    public VideoContentDetails? ContentDetails { get; set; }
+    public VideoStatistics? Statistics { get; set; }
+    public VideoPlayer? Player { get; set; }
+    public VideoLiveStreamingDetails? LiveStreamingDetails { get; set; }
+    public Dictionary<string, YouTubeLocalizedResource>? Localizations { get; set; }
+}

--- a/src/Videos/VideoResource.cs
+++ b/src/Videos/VideoResource.cs
@@ -13,10 +13,16 @@ public class VideoResource
 
     public string? Id { get; set; }
     public VideoSnippet? Snippet { get; set; }
-    public VideoStatus? Status { get; set; }
     public VideoContentDetails? ContentDetails { get; set; }
+    public VideoStatus? Status { get; set; }
     public VideoStatistics? Statistics { get; set; }
+    public VideoPaidProductPlacementDetails? PaidProductPlacementDetails { get; set; }
     public VideoPlayer? Player { get; set; }
+    public VideoTopicDetails? TopicDetails { get; set; }
+    public VideoRecordingDetails? RecordingDetails { get; set; }
+    public VideoFileDetails? FileDetails { get; set; }
+    public VideoProcessingDetails? ProcessingDetails { get; set; }
+    public VideoSuggestions? Suggestions { get; set; }
     public VideoLiveStreamingDetails? LiveStreamingDetails { get; set; }
     public Dictionary<string, YouTubeLocalizedResource>? Localizations { get; set; }
 }

--- a/src/Videos/VideoSnippet.cs
+++ b/src/Videos/VideoSnippet.cs
@@ -1,0 +1,21 @@
+// Licensed under the MIT license by loonfactory.
+
+using Loonfactory.Google.Apis.YouTube.V3.Thumbnails;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoSnippet
+{
+    public DateTimeOffset? PublishedAt { get; set; }
+    public string? ChannelId { get; set; }
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public Dictionary<string, Thumbnail>? Thumbnails { get; set; }
+    public string? ChannelTitle { get; set; }
+    public IEnumerable<string>? Tags { get; set; }
+    public string? CategoryId { get; set; }
+    public string? LiveBroadcastContent { get; set; }
+    public string? DefaultLanguage { get; set; }
+    public YouTubeLocalizedResource? Localized { get; set; }
+    public string? DefaultAudioLanguage { get; set; }
+}

--- a/src/Videos/VideoStatistics.cs
+++ b/src/Videos/VideoStatistics.cs
@@ -1,0 +1,11 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoStatistics
+{
+    public ulong? ViewCount { get; set; }
+    public ulong? LikeCount { get; set; }
+    public ulong? FavoriteCount { get; set; }
+    public ulong? CommentCount { get; set; }
+}

--- a/src/Videos/VideoStatistics.cs
+++ b/src/Videos/VideoStatistics.cs
@@ -6,6 +6,7 @@ public class VideoStatistics
 {
     public ulong? ViewCount { get; set; }
     public ulong? LikeCount { get; set; }
+    public ulong? DislikeCount { get; set; }
     public ulong? FavoriteCount { get; set; }
     public ulong? CommentCount { get; set; }
 }

--- a/src/Videos/VideoStatus.cs
+++ b/src/Videos/VideoStatus.cs
@@ -5,10 +5,14 @@ namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
 public class VideoStatus
 {
     public string? UploadStatus { get; set; }
+    public string? FailureReason { get; set; }
+    public string? RejectionReason { get; set; }
     public string? PrivacyStatus { get; set; }
+    public DateTimeOffset? PublishAt { get; set; }
     public string? License { get; set; }
     public bool? Embeddable { get; set; }
     public bool? PublicStatsViewable { get; set; }
     public bool? MadeForKids { get; set; }
     public bool? SelfDeclaredMadeForKids { get; set; }
+    public bool? ContainsSyntheticMedia { get; set; }
 }

--- a/src/Videos/VideoStatus.cs
+++ b/src/Videos/VideoStatus.cs
@@ -1,0 +1,14 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoStatus
+{
+    public string? UploadStatus { get; set; }
+    public string? PrivacyStatus { get; set; }
+    public string? License { get; set; }
+    public bool? Embeddable { get; set; }
+    public bool? PublicStatsViewable { get; set; }
+    public bool? MadeForKids { get; set; }
+    public bool? SelfDeclaredMadeForKids { get; set; }
+}

--- a/src/Videos/VideoSuggestions.cs
+++ b/src/Videos/VideoSuggestions.cs
@@ -1,0 +1,12 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoSuggestions
+{
+    public IEnumerable<string>? ProcessingErrors { get; set; }
+    public IEnumerable<string>? ProcessingWarnings { get; set; }
+    public IEnumerable<string>? ProcessingHints { get; set; }
+    public IEnumerable<VideoSuggestionsTagSuggestion>? TagSuggestions { get; set; }
+    public IEnumerable<string>? EditorSuggestions { get; set; }
+}

--- a/src/Videos/VideoSuggestionsTagSuggestion.cs
+++ b/src/Videos/VideoSuggestionsTagSuggestion.cs
@@ -1,0 +1,9 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoSuggestionsTagSuggestion
+{
+    public string? Tag { get; set; }
+    public IEnumerable<string>? CategoryRestricts { get; set; }
+}

--- a/src/Videos/VideoTopicDetails.cs
+++ b/src/Videos/VideoTopicDetails.cs
@@ -1,0 +1,10 @@
+// Licensed under the MIT license by loonfactory.
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideoTopicDetails
+{
+    public IEnumerable<string>? TopicIds { get; set; }
+    public IEnumerable<string>? RelevantTopicIds { get; set; }
+    public IEnumerable<string>? TopicCategories { get; set; }
+}

--- a/src/Videos/VideosService.cs
+++ b/src/Videos/VideosService.cs
@@ -1,0 +1,403 @@
+// Licensed under the MIT license by loonfactory.
+
+using Microsoft.Extensions.Primitives;
+
+namespace Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+public class VideosService(
+    IYouTubeHandlerProvider handlers,
+    IAccessTokenProvider accessTokenProvider
+) : IVideosService
+{
+    public IYouTubeHandlerProvider Handlers { get; } = handlers;
+
+    public IAccessTokenProvider AccessTokenProvider { get; } = accessTokenProvider;
+
+    public Task<VideoListResponse> ListByIdAsync(
+        StringValues part,
+        StringValues id,
+        uint? maxResults = null,
+        string? pageToken = null,
+        string? hl = null,
+        string? regionCode = null,
+        string? videoCategoryId = null,
+        uint? maxHeight = null,
+        uint? maxWidth = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(part))
+        {
+            throw new ArgumentException("part must be provided.", nameof(part));
+        }
+
+        if (StringValues.IsNullOrEmpty(id))
+        {
+            throw new ArgumentException("id must be provided.", nameof(id));
+        }
+
+        return ListAsync(
+            part,
+            new(nameof(id), id),
+            maxResults,
+            pageToken,
+            hl,
+            regionCode,
+            videoCategoryId,
+            maxHeight,
+            maxWidth,
+            onBehalfOfContentOwner,
+            cancellationToken);
+    }
+
+    public Task<VideoListResponse> ListByChartAsync(
+        StringValues part,
+        string chart,
+        uint? maxResults = null,
+        string? pageToken = null,
+        string? hl = null,
+        string? regionCode = null,
+        string? videoCategoryId = null,
+        uint? maxHeight = null,
+        uint? maxWidth = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(part))
+        {
+            throw new ArgumentException("part must be provided.", nameof(part));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(chart);
+
+        return ListAsync(
+            part,
+            new(nameof(chart), chart),
+            maxResults,
+            pageToken,
+            hl,
+            regionCode,
+            videoCategoryId,
+            maxHeight,
+            maxWidth,
+            onBehalfOfContentOwner,
+            cancellationToken);
+    }
+
+    public Task<VideoListResponse> ListByMyRatingAsync(
+        StringValues part,
+        string myRating,
+        uint? maxResults = null,
+        string? pageToken = null,
+        string? hl = null,
+        uint? maxHeight = null,
+        uint? maxWidth = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(part))
+        {
+            throw new ArgumentException("part must be provided.", nameof(part));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(myRating);
+
+        return ListAsync(
+            part,
+            new(nameof(myRating), myRating),
+            maxResults,
+            pageToken,
+            hl,
+            regionCode: null,
+            videoCategoryId: null,
+            maxHeight,
+            maxWidth,
+            onBehalfOfContentOwner,
+            cancellationToken);
+    }
+
+    private async Task<VideoListResponse> ListAsync(
+        StringValues part,
+        KeyValuePair<string, object> filter,
+        uint? maxResults,
+        string? pageToken,
+        string? hl,
+        string? regionCode,
+        string? videoCategoryId,
+        uint? maxHeight,
+        uint? maxWidth,
+        string? onBehalfOfContentOwner,
+        CancellationToken cancellationToken)
+    {
+        var handler = await Handlers.GetHandlerAsync<VideoHandler>()
+                                    .ConfigureAwait(false) ?? throw new InvalidOperationException("VideoHandler could not be obtained.");
+
+        var properties = new VideoProperties
+        {
+            Part = part,
+            MaxResults = maxResults,
+            PageToken = pageToken,
+            Hl = hl,
+            RegionCode = regionCode,
+            VideoCategoryId = videoCategoryId,
+            MaxHeight = maxHeight,
+            MaxWidth = maxWidth,
+            OnBehalfOfContentOwner = onBehalfOfContentOwner,
+            AccessToken = await AccessTokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false)
+        };
+
+        properties.Parameters.Add(filter.Key, filter.Value);
+
+        var result = await handler.HandleVideoListAsync(properties, cancellationToken)
+                                  .ConfigureAwait(false);
+
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException("Video list request failed. [TODO: unify error handling]");
+        }
+
+        return result.Resource;
+    }
+
+    public Task<VideoResource> InsertAsync(
+        StringValues part,
+        VideoResource resource,
+        StreamContent? content = null,
+        bool? autoLevels = null,
+        bool? notifySubscribers = null,
+        string? onBehalfOfContentOwner = null,
+        string? onBehalfOfContentOwnerChannel = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(part))
+        {
+            throw new ArgumentException("part must be provided.", nameof(part));
+        }
+
+        ArgumentNullException.ThrowIfNull(resource);
+
+        if (resource.Snippet == null)
+        {
+            throw new InvalidOperationException("Snippet must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(resource.Snippet.Title))
+        {
+            throw new InvalidOperationException("Snippet.Title must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(resource.Snippet.CategoryId))
+        {
+            throw new InvalidOperationException("Snippet.CategoryId must be set.");
+        }
+
+        return InternalInsertAsync(
+            part,
+            resource,
+            content,
+            autoLevels,
+            notifySubscribers,
+            onBehalfOfContentOwner,
+            onBehalfOfContentOwnerChannel,
+            cancellationToken
+        );
+    }
+
+    private async Task<VideoResource> InternalInsertAsync(
+        StringValues part,
+        VideoResource resource,
+        StreamContent? content,
+        bool? autoLevels,
+        bool? notifySubscribers,
+        string? onBehalfOfContentOwner,
+        string? onBehalfOfContentOwnerChannel,
+        CancellationToken cancellationToken)
+    {
+        var handler = await Handlers.GetHandlerAsync<VideoHandler>()
+                                    .ConfigureAwait(false) ?? throw new InvalidOperationException("VideoHandler could not be obtained.");
+
+        var properties = new VideoProperties
+        {
+            Part = part,
+            AutoLevels = autoLevels,
+            NotifySubscribers = notifySubscribers,
+            OnBehalfOfContentOwner = onBehalfOfContentOwner,
+            OnBehalfOfContentOwnerChannel = onBehalfOfContentOwnerChannel,
+            AccessToken = await AccessTokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false)
+        };
+
+        var result = await handler.HandleVideoInsertAsync(resource, content, properties, cancellationToken).ConfigureAwait(false);
+        return result.Succeeded switch
+        {
+            true => result.Resource,
+            false => throw new NotImplementedException("@TODO")
+        };
+    }
+
+    public Task<VideoResource> UpdateAsync(
+        StringValues part,
+        VideoResource resource,
+        StreamContent? content = null,
+        bool? notifySubscribers = null,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(part))
+        {
+            throw new ArgumentException("part must be provided.", nameof(part));
+        }
+
+        ArgumentNullException.ThrowIfNull(resource);
+
+        if (string.IsNullOrWhiteSpace(resource.Id))
+        {
+            throw new InvalidOperationException("Resource.Id must be set for update.");
+        }
+
+        return InternalUpdateAsync(
+            part,
+            resource,
+            content,
+            notifySubscribers,
+            onBehalfOfContentOwner,
+            cancellationToken);
+    }
+
+    private async Task<VideoResource> InternalUpdateAsync(
+        StringValues part,
+        VideoResource resource,
+        StreamContent? content,
+        bool? notifySubscribers,
+        string? onBehalfOfContentOwner,
+        CancellationToken cancellationToken)
+    {
+        var handler = await Handlers.GetHandlerAsync<VideoHandler>()
+                                    .ConfigureAwait(false) ?? throw new InvalidOperationException("VideoHandler could not be obtained.");
+
+        var properties = new VideoProperties
+        {
+            Part = part,
+            NotifySubscribers = notifySubscribers,
+            OnBehalfOfContentOwner = onBehalfOfContentOwner,
+            AccessToken = await AccessTokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false)
+        };
+
+        var result = await handler.HandleVideoUpdateAsync(resource, content, properties, cancellationToken).ConfigureAwait(false);
+        return result.Succeeded switch
+        {
+            true => result.Resource,
+            false => throw new NotImplementedException("@TODO")
+        };
+    }
+
+    public async Task DeleteAsync(
+        StringValues id,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(id))
+        {
+            throw new ArgumentException("id must be provided.", nameof(id));
+        }
+
+        var handler = await Handlers.GetHandlerAsync<VideoHandler>()
+                                    .ConfigureAwait(false) ?? throw new InvalidOperationException("VideoHandler could not be obtained.");
+
+        var properties = new VideoProperties
+        {
+            Id = id,
+            OnBehalfOfContentOwner = onBehalfOfContentOwner,
+            AccessToken = await AccessTokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false)
+        };
+
+        var result = await handler.HandleVideoDeleteAsync(properties, cancellationToken).ConfigureAwait(false);
+        if (result.Succeeded)
+        {
+            return;
+        }
+
+        throw new NotImplementedException("@TODO");
+    }
+
+    public async Task RateAsync(
+        StringValues id,
+        string rating,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(id))
+        {
+            throw new ArgumentException("id must be provided.", nameof(id));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(rating);
+
+        var handler = await Handlers.GetHandlerAsync<VideoHandler>()
+                                    .ConfigureAwait(false) ?? throw new InvalidOperationException("VideoHandler could not be obtained.");
+
+        var properties = new VideoProperties
+        {
+            Id = id,
+            Rating = rating,
+            AccessToken = await AccessTokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false)
+        };
+
+        var result = await handler.HandleVideoRateAsync(properties, cancellationToken).ConfigureAwait(false);
+        if (result.Succeeded)
+        {
+            return;
+        }
+
+        throw new NotImplementedException("@TODO");
+    }
+
+    public async Task<VideoGetRatingResponse> GetRatingAsync(
+        StringValues id,
+        string? onBehalfOfContentOwner = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (StringValues.IsNullOrEmpty(id))
+        {
+            throw new ArgumentException("id must be provided.", nameof(id));
+        }
+
+        var handler = await Handlers.GetHandlerAsync<VideoHandler>()
+                                    .ConfigureAwait(false) ?? throw new InvalidOperationException("VideoHandler could not be obtained.");
+
+        var properties = new VideoProperties
+        {
+            Id = id,
+            OnBehalfOfContentOwner = onBehalfOfContentOwner,
+            AccessToken = await AccessTokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false)
+        };
+
+        var result = await handler.HandleVideoGetRatingAsync(properties, cancellationToken).ConfigureAwait(false);
+        return result.Succeeded switch
+        {
+            true => result.Resource,
+            false => throw new NotImplementedException("@TODO")
+        };
+    }
+
+    public async Task ReportAbuseAsync(
+        VideoReportAbuseRequest resource,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        var handler = await Handlers.GetHandlerAsync<VideoHandler>()
+                                    .ConfigureAwait(false) ?? throw new InvalidOperationException("VideoHandler could not be obtained.");
+
+        var properties = new VideoProperties
+        {
+            AccessToken = await AccessTokenProvider.GetAccessTokenAsync(cancellationToken).ConfigureAwait(false)
+        };
+
+        var result = await handler.HandleVideoReportAbuseAsync(resource, properties, cancellationToken).ConfigureAwait(false);
+        if (result.Succeeded)
+        {
+            return;
+        }
+
+        throw new NotImplementedException("@TODO");
+    }
+}

--- a/src/YouTubeDataApiBuilder.cs
+++ b/src/YouTubeDataApiBuilder.cs
@@ -17,6 +17,7 @@ using Loonfactory.Google.Apis.YouTube.V3.Subscriptions;
 using Loonfactory.Google.Apis.YouTube.V3.Thumbnails;
 using Loonfactory.Google.Apis.YouTube.V3.VideoAbuseReportReasons;
 using Loonfactory.Google.Apis.YouTube.V3.VideoCategories;
+using Loonfactory.Google.Apis.YouTube.V3.Videos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -200,6 +201,21 @@ public class YouTubeDataApiBuilder(IServiceCollection services)
         where THandler : class, IVideoCategoryHandler
     {
         Services.TryAddScoped<IVideoCategoryService, TYouTubeVideoCategories>();
+        AddHandler<THandler>();
+
+        return this;
+    }
+
+    public virtual YouTubeDataApiBuilder AddVideos()
+    {
+        return AddVideos<VideosService, VideoHandler>();
+    }
+
+    public virtual YouTubeDataApiBuilder AddVideos<TYouTubeVideos, THandler>()
+        where TYouTubeVideos : class, IVideosService
+        where THandler : class, IVideoHandler
+    {
+        Services.TryAddScoped<IVideosService, TYouTubeVideos>();
         AddHandler<THandler>();
 
         return this;

--- a/src/YouTubeDataApiServiceCollectionExtensions.cs
+++ b/src/YouTubeDataApiServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Loonfactory.Google.Apis.YouTube.V3.Subscriptions;
 using Loonfactory.Google.Apis.YouTube.V3.Thumbnails;
 using Loonfactory.Google.Apis.YouTube.V3.VideoAbuseReportReasons;
 using Loonfactory.Google.Apis.YouTube.V3.VideoCategories;
+using Loonfactory.Google.Apis.YouTube.V3.Videos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -73,6 +74,7 @@ public static class YouTubeDataApiServiceCollectionExtensions
         builder.AddThumbnails<ThumbnailService, ThumbnailHandler>();
         builder.AddVideoAbuseReportReasons<VideoAbuseReportReasonsService, VideoAbuseReportReasonHandler>();
         builder.AddVideoCategories<VideoCategoryService, VideoCategoryHandler>();
+        builder.AddVideos<VideosService, VideoHandler>();
 
         return builder;
     }

--- a/src/YouTubeDefaults.cs
+++ b/src/YouTubeDefaults.cs
@@ -1,6 +1,7 @@
 // Licensed under the MIT license by loonfactory.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Loonfactory.Google.Apis.YouTube.V3;
 
@@ -8,6 +9,7 @@ public static class YouTubeDefaults
 {
     public static JsonSerializerOptions JsonSerializerOptions { get; } = new JsonSerializerOptions
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString
     };
 }

--- a/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Fixtures/video-list-user.json
+++ b/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Fixtures/video-list-user.json
@@ -1,0 +1,78 @@
+{
+  "kind": "youtube#videoListResponse",
+  "etag": "F4bXoRsap05l2sJcPldJQFhBBns",
+  "items": [
+    {
+      "kind": "youtube#video",
+      "etag": "10lhRp97WIlHee0GUxNGg4eMTA8",
+      "id": "0e3GPea1Tyg",
+      "snippet": {
+        "publishedAt": "2021-11-24T21:00:01Z",
+        "channelId": "UCX6OQ3DkcsbYNE6H8uQQuVA",
+        "title": "$456,000 Squid Game In Real Life!",
+        "description": "desc",
+        "thumbnails": {
+          "default": {
+            "url": "https://i.ytimg.com/vi/0e3GPea1Tyg/default.jpg",
+            "width": 120,
+            "height": 90
+          }
+        },
+        "channelTitle": "MrBeast",
+        "categoryId": "24",
+        "liveBroadcastContent": "none",
+        "defaultLanguage": "en",
+        "localized": {
+          "title": "$456,000 Squid Game In Real Life!",
+          "description": "desc"
+        },
+        "defaultAudioLanguage": "en"
+      },
+      "contentDetails": {
+        "duration": "PT25M42S",
+        "dimension": "2d",
+        "definition": "hd",
+        "caption": "true",
+        "licensedContent": true,
+        "contentRating": {},
+        "projection": "rectangular"
+      },
+      "status": {
+        "uploadStatus": "processed",
+        "privacyStatus": "public",
+        "license": "youtube",
+        "embeddable": true,
+        "publicStatsViewable": true,
+        "madeForKids": false
+      },
+      "statistics": {
+        "viewCount": "914000309",
+        "likeCount": "19894449",
+        "favoriteCount": "0",
+        "commentCount": "645441"
+      },
+      "player": {
+        "embedHtml": "<iframe></iframe>"
+      },
+      "topicDetails": {
+        "topicCategories": [
+          "https://en.wikipedia.org/wiki/Lifestyle_(sociology)"
+        ]
+      },
+      "recordingDetails": {},
+      "localizations": {
+        "ko": {
+          "title": "한국어 제목",
+          "description": "한국어 설명"
+        }
+      },
+      "paidProductPlacementDetails": {
+        "hasPaidProductPlacement": false
+      }
+    }
+  ],
+  "pageInfo": {
+    "totalResults": 1,
+    "resultsPerPage": 1
+  }
+}

--- a/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Loonfactory.Google.Apis.YouTube.V3.Tests.csproj
+++ b/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Loonfactory.Google.Apis.YouTube.V3.Tests.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="Fixtures\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Loonfactory.Google.Apis.YouTube.V3.csproj" />
   </ItemGroup>
 

--- a/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideoListResponseSerializationTests.cs
+++ b/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideoListResponseSerializationTests.cs
@@ -1,0 +1,46 @@
+// Licensed under the MIT license by loonfactory.
+
+using System.Text.Json;
+using Loonfactory.Google.Apis.YouTube.V3.Videos;
+
+namespace Loonfactory.Google.Apis.YouTube.V3;
+
+public sealed class VideoListResponseSerializationTests
+{
+    [Fact]
+    public void Deserialize_WithUserProvidedVideoListJson_MapsFields()
+    {
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "video-list-user.json");
+        var json = File.ReadAllText(fixturePath);
+
+        var response = JsonSerializer.Deserialize<VideoListResponse>(json, YouTubeDefaults.JsonSerializerOptions);
+
+        Assert.NotNull(response);
+        Assert.Equal("youtube#videoListResponse", response!.Kind);
+        Assert.Equal(1, response.PageInfo!.TotalResults);
+        Assert.Equal(1, response.PageInfo.ResultsPerPage);
+
+        var item = Assert.Single(response.Items!);
+
+        Assert.Equal("0e3GPea1Tyg", item.Id);
+        Assert.Equal("$456,000 Squid Game In Real Life!", item.Snippet!.Title);
+        Assert.Equal("https://i.ytimg.com/vi/0e3GPea1Tyg/default.jpg", item.Snippet.Thumbnails!["default"].Url);
+
+        Assert.NotNull(item.ContentDetails!.ContentRating);
+        Assert.Equal("rectangular", item.ContentDetails.Projection);
+
+        Assert.Equal("processed", item.Status!.UploadStatus);
+        Assert.True(item.Status.Embeddable);
+        Assert.False(item.Status.MadeForKids);
+
+        Assert.Equal((ulong)914000309, item.Statistics!.ViewCount);
+        Assert.Equal((ulong)19894449, item.Statistics.LikeCount);
+
+        Assert.False(item.PaidProductPlacementDetails!.HasPaidProductPlacement);
+        Assert.Equal(
+            "https://en.wikipedia.org/wiki/Lifestyle_(sociology)",
+            item.TopicDetails!.TopicCategories!.Single());
+        Assert.NotNull(item.RecordingDetails);
+        Assert.Equal("한국어 제목", item.Localizations!["ko"].Title);
+    }
+}

--- a/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideoPropertiesTests.cs
+++ b/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideoPropertiesTests.cs
@@ -1,0 +1,78 @@
+// Licensed under the MIT license by loonfactory.
+
+using Loonfactory.Google.Apis.YouTube.V3.Videos;
+using Microsoft.Extensions.Primitives;
+
+namespace Loonfactory.Google.Apis.YouTube.V3;
+
+public sealed class VideoPropertiesTests
+{
+    [Fact]
+    public void Constructor_WithItems_UsesProvidedItemsDictionary()
+    {
+        var items = new Dictionary<string, string?>
+        {
+            ["state"] = "value"
+        };
+
+        var properties = new VideoProperties(items);
+
+        Assert.Same(items, properties.Items);
+        Assert.Equal("value", properties.Items["state"]);
+    }
+
+    [Fact]
+    public void Constructor_WithItemsAndParameters_UsesProvidedDictionaries()
+    {
+        var items = new Dictionary<string, string?>();
+        var parameters = new Dictionary<string, object?>
+        {
+            [VideoProperties.PartKey] = new StringValues("snippet")
+        };
+
+        var properties = new VideoProperties(items, parameters);
+
+        Assert.Same(items, properties.Items);
+        Assert.Same(parameters, properties.Parameters);
+    }
+
+    [Fact]
+    public void Part_RoundTripsValue()
+    {
+        var properties = new VideoProperties();
+
+        properties.Part = "snippet";
+
+        Assert.Equal("snippet", properties.Part.ToString());
+    }
+
+    [Fact]
+    public void Id_RoundTripsValue()
+    {
+        var properties = new VideoProperties();
+
+        properties.Id = "abc123";
+
+        Assert.Equal("abc123", properties.Id.ToString());
+    }
+
+    [Fact]
+    public void Chart_RoundTripsValue()
+    {
+        var properties = new VideoProperties();
+
+        properties.Chart = "mostPopular";
+
+        Assert.Equal("mostPopular", properties.Chart);
+    }
+
+    [Fact]
+    public void NotifySubscribers_RoundTripsValue()
+    {
+        var properties = new VideoProperties();
+
+        properties.NotifySubscribers = true;
+
+        Assert.True(properties.NotifySubscribers);
+    }
+}

--- a/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideosServiceTests.cs
+++ b/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideosServiceTests.cs
@@ -93,6 +93,50 @@ public sealed class VideosServiceTests(VideosServiceFixture fixture) : IClassFix
     }
 
     [Fact]
+    public async Task ListByMyRatingAsync_SendsExpectedQuery()
+    {
+        HttpRequestMessage? captured = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(VideosServiceFixture.ValidVideosListJson, Encoding.UTF8, "application/json")
+            };
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await service.ListByMyRatingAsync(
+            part: "snippet",
+            myRating: "like",
+            maxResults: 5,
+            pageToken: "PAGE_2",
+            hl: "ko",
+            maxHeight: 720,
+            maxWidth: 1280,
+            onBehalfOfContentOwner: "owner-1",
+            cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Get, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/youtube/v3/videos", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        var query = QueryHelpers.ParseQuery(captured.RequestUri.Query);
+        Assert.Equal("snippet", query["part"]);
+        Assert.Equal("like", query["myRating"]);
+        Assert.Equal("5", query["maxResults"]);
+        Assert.Equal("PAGE_2", query["pageToken"]);
+        Assert.Equal("ko", query["hl"]);
+        Assert.Equal("720", query["maxHeight"]);
+        Assert.Equal("1280", query["maxWidth"]);
+        Assert.Equal("owner-1", query["onBehalfOfContentOwner"]);
+        Assert.Equal("test-api-key", query["key"]);
+    }
+
+    [Fact]
     public async Task InsertAsync_SendsExpectedRequest_WithAuthorizationHeader()
     {
         HttpRequestMessage? captured = null;
@@ -145,6 +189,69 @@ public sealed class VideosServiceTests(VideosServiceFixture fixture) : IClassFix
 
         Assert.Contains("\"title\":\"Test video\"", capturedBody);
         Assert.Contains("\"categoryId\":\"22\"", capturedBody);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SendsExpectedRequest_WithAuthorizationHeader()
+    {
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            if (request.Content is not null)
+            {
+                using var stream = request.Content.ReadAsStream();
+                using var reader = new StreamReader(stream);
+                capturedBody = reader.ReadToEnd();
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(VideosServiceFixture.ValidVideoResourceJson, Encoding.UTF8, "application/json")
+            };
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await service.UpdateAsync(
+            part: "snippet,status",
+            resource: new VideoResource
+            {
+                Id = "abc123",
+                Snippet = new VideoSnippet
+                {
+                    Title = "Updated title",
+                    CategoryId = "22"
+                },
+                Status = new VideoStatus
+                {
+                    PrivacyStatus = "public"
+                }
+            },
+            notifySubscribers: false,
+            onBehalfOfContentOwner: "owner-1",
+            cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Put, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/upload/youtube/v3/videos", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        var query = QueryHelpers.ParseQuery(captured.RequestUri.Query);
+        Assert.Equal("snippet,status", query["part"]);
+        Assert.Equal("False", query["notifySubscribers"]);
+        Assert.Equal("owner-1", query["onBehalfOfContentOwner"]);
+        Assert.Equal("test-api-key", query["key"]);
+
+        Assert.NotNull(captured.Headers.Authorization);
+        Assert.Equal("Bearer", captured.Headers.Authorization!.Scheme);
+        Assert.Equal("test-access-token", captured.Headers.Authorization.Parameter);
+
+        Assert.Contains("\"id\":\"abc123\"", capturedBody);
+        Assert.Contains("\"title\":\"Updated title\"", capturedBody);
+        Assert.Contains("\"privacyStatus\":\"public\"", capturedBody);
     }
 
     [Fact]
@@ -287,6 +394,26 @@ public sealed class VideosServiceTests(VideosServiceFixture fixture) : IClassFix
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
             service.RateAsync(id: "abc123", rating: " "));
+    }
+
+    [Fact]
+    public async Task ListByMyRatingAsync_ThrowsWhenMyRatingIsWhitespace()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.ListByMyRatingAsync(part: "snippet", myRating: " "));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThrowsWhenResourceIdIsMissing()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.UpdateAsync(part: "snippet", resource: new VideoResource()));
     }
 }
 

--- a/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideosServiceTests.cs
+++ b/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideosServiceTests.cs
@@ -52,6 +52,7 @@ public sealed class VideosServiceTests(VideosServiceFixture fixture) : IClassFix
 
         Assert.Equal("youtube#videoListResponse", response.Kind);
         Assert.Single(response.Items!);
+        Assert.Equal("ytAgeRestricted", response.Items!.Single().ContentDetails!.ContentRating!.YtRating);
     }
 
     [Fact]
@@ -300,6 +301,11 @@ public sealed class VideosServiceFixture : IAsyncLifetime
           "kind": "youtube#video",
           "etag": "video-etag",
           "id": "abc123",
+          "contentDetails": {
+            "contentRating": {
+              "ytRating": "ytAgeRestricted"
+            }
+          },
           "snippet": {
             "title": "Test video",
             "categoryId": "22"

--- a/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideosServiceTests.cs
+++ b/tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Videos/VideosServiceTests.cs
@@ -1,0 +1,385 @@
+// Licensed under the MIT license by loonfactory.
+
+using System.Net;
+using System.Text;
+using Loonfactory.Google.Apis.YouTube.V3.Tests;
+using Loonfactory.Google.Apis.YouTube.V3.Videos;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Primitives;
+
+namespace Loonfactory.Google.Apis.YouTube.V3;
+
+public sealed class VideosServiceTests(VideosServiceFixture fixture) : IClassFixture<VideosServiceFixture>
+{
+    [Fact]
+    public async Task ListByIdAsync_SendsExpectedRequest_AndReturnsResponseBody()
+    {
+        HttpRequestMessage? captured = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(VideosServiceFixture.ValidVideosListJson, Encoding.UTF8, "application/json")
+            };
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        var response = await service.ListByIdAsync(
+            part: "snippet",
+            id: "abc123",
+            maxResults: 5,
+            pageToken: "PAGE_1",
+            cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Get, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/youtube/v3/videos", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        var query = QueryHelpers.ParseQuery(captured.RequestUri.Query);
+        Assert.Equal("snippet", query["part"]);
+        Assert.Equal("abc123", query["id"]);
+        Assert.Equal("5", query["maxResults"]);
+        Assert.Equal("PAGE_1", query["pageToken"]);
+        Assert.Equal("test-api-key", query["key"]);
+
+        Assert.Equal("youtube#videoListResponse", response.Kind);
+        Assert.Single(response.Items!);
+    }
+
+    [Fact]
+    public async Task ListByChartAsync_SendsExpectedQuery()
+    {
+        HttpRequestMessage? captured = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(VideosServiceFixture.ValidVideosListJson, Encoding.UTF8, "application/json")
+            };
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await service.ListByChartAsync(
+            part: "snippet",
+            chart: "mostPopular",
+            regionCode: "KR",
+            videoCategoryId: "10",
+            maxHeight: 720,
+            maxWidth: 1280,
+            cancellationToken: default);
+
+        Assert.NotNull(captured);
+
+        var query = QueryHelpers.ParseQuery(captured!.RequestUri!.Query);
+        Assert.Equal("snippet", query["part"]);
+        Assert.Equal("mostPopular", query["chart"]);
+        Assert.Equal("KR", query["regionCode"]);
+        Assert.Equal("10", query["videoCategoryId"]);
+        Assert.Equal("720", query["maxHeight"]);
+        Assert.Equal("1280", query["maxWidth"]);
+    }
+
+    [Fact]
+    public async Task InsertAsync_SendsExpectedRequest_WithAuthorizationHeader()
+    {
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            if (request.Content is not null)
+            {
+                using var stream = request.Content.ReadAsStream();
+                using var reader = new StreamReader(stream);
+                capturedBody = reader.ReadToEnd();
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(VideosServiceFixture.ValidVideoResourceJson, Encoding.UTF8, "application/json")
+            };
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await service.InsertAsync(
+            part: "snippet",
+            resource: new VideoResource
+            {
+                Snippet = new VideoSnippet
+                {
+                    Title = "Test video",
+                    CategoryId = "22"
+                }
+            },
+            notifySubscribers: true,
+            cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/upload/youtube/v3/videos", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        var query = QueryHelpers.ParseQuery(captured.RequestUri.Query);
+        Assert.Equal("snippet", query["part"]);
+        Assert.Equal("True", query["notifySubscribers"]);
+        Assert.Equal("test-api-key", query["key"]);
+
+        Assert.NotNull(captured.Headers.Authorization);
+        Assert.Equal("Bearer", captured.Headers.Authorization!.Scheme);
+        Assert.Equal("test-access-token", captured.Headers.Authorization.Parameter);
+
+        Assert.Contains("\"title\":\"Test video\"", capturedBody);
+        Assert.Contains("\"categoryId\":\"22\"", capturedBody);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SendsExpectedRequest()
+    {
+        HttpRequestMessage? captured = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await service.DeleteAsync("abc123", cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Delete, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/youtube/v3/videos", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        var query = QueryHelpers.ParseQuery(captured.RequestUri.Query);
+        Assert.Equal("abc123", query["id"]);
+
+        Assert.NotNull(captured.Headers.Authorization);
+        Assert.Equal("Bearer", captured.Headers.Authorization!.Scheme);
+    }
+
+    [Fact]
+    public async Task RateAsync_SendsExpectedRequest()
+    {
+        HttpRequestMessage? captured = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await service.RateAsync(id: "abc123", rating: "like", cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/youtube/v3/videos/rate", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        var query = QueryHelpers.ParseQuery(captured.RequestUri.Query);
+        Assert.Equal("abc123", query["id"]);
+        Assert.Equal("like", query["rating"]);
+    }
+
+    [Fact]
+    public async Task GetRatingAsync_SendsExpectedRequest_AndReturnsResponseBody()
+    {
+        HttpRequestMessage? captured = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(VideosServiceFixture.ValidGetRatingJson, Encoding.UTF8, "application/json")
+            };
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        var response = await service.GetRatingAsync(id: "abc123", cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Get, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/youtube/v3/videos/getRating", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        var query = QueryHelpers.ParseQuery(captured.RequestUri.Query);
+        Assert.Equal("abc123", query["id"]);
+
+        Assert.Equal("youtube#videoGetRatingResponse", response.Kind);
+        Assert.Equal("like", response.Items!.Single().Rating);
+    }
+
+    [Fact]
+    public async Task ReportAbuseAsync_SendsExpectedRequestBody()
+    {
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+
+        fixture.BackchannelHandler.Sender = request =>
+        {
+            captured = request;
+            if (request.Content is not null)
+            {
+                using var stream = request.Content.ReadAsStream();
+                using var reader = new StreamReader(stream);
+                capturedBody = reader.ReadToEnd();
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        };
+
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await service.ReportAbuseAsync(
+            new VideoReportAbuseRequest
+            {
+                VideoId = "abc123",
+                ReasonId = "32",
+                SecondaryReasonId = "89"
+            },
+            cancellationToken: default);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.Equal("https://www.googleapis.com/youtube/v3/videos/reportAbuse", captured.RequestUri!.GetLeftPart(UriPartial.Path));
+
+        Assert.Contains("\"videoId\":\"abc123\"", capturedBody);
+        Assert.Contains("\"reasonId\":\"32\"", capturedBody);
+        Assert.Contains("\"secondaryReasonId\":\"89\"", capturedBody);
+    }
+
+    [Fact]
+    public async Task ListByIdAsync_ThrowsWhenPartIsMissing()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.ListByIdAsync(part: StringValues.Empty, id: "abc123"));
+    }
+
+    [Fact]
+    public async Task RateAsync_ThrowsWhenRatingIsWhitespace()
+    {
+        using var scope = fixture.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IVideosService>();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.RateAsync(id: "abc123", rating: " "));
+    }
+}
+
+public sealed class VideosServiceFixture : IAsyncLifetime
+{
+    public const string ValidVideosListJson = """
+    {
+      "kind": "youtube#videoListResponse",
+      "etag": "test-etag",
+      "items": [
+        {
+          "kind": "youtube#video",
+          "etag": "video-etag",
+          "id": "abc123",
+          "snippet": {
+            "title": "Test video",
+            "categoryId": "22"
+          }
+        }
+      ]
+    }
+    """;
+
+    public const string ValidVideoResourceJson = """
+    {
+      "kind": "youtube#video",
+      "etag": "video-etag",
+      "id": "abc123",
+      "snippet": {
+        "title": "Test video",
+        "categoryId": "22"
+      }
+    }
+    """;
+
+    public const string ValidGetRatingJson = """
+    {
+      "kind": "youtube#videoGetRatingResponse",
+      "etag": "rating-etag",
+      "items": [
+        {
+          "videoId": "abc123",
+          "rating": "like"
+        }
+      ]
+    }
+    """;
+
+    public TestHttpMessageHandler BackchannelHandler { get; } = new();
+
+    public IServiceProvider Services => _host?.Services ?? throw new InvalidOperationException("The fixture host is not initialized.");
+
+    private IHost? _host;
+
+    public async Task InitializeAsync()
+    {
+        var backchannel = new HttpClient(BackchannelHandler);
+
+        _host = new HostBuilder()
+            .ConfigureWebHost(builder =>
+                builder.UseTestServer()
+                    .Configure(_ => { })
+                    .ConfigureServices(services =>
+                    {
+                        services.AddOptions<YouTubeOptions>()
+                            .Configure(options =>
+                            {
+                                options.Key = "test-api-key";
+                                options.Backchannel = backchannel;
+                            });
+
+                        services.AddYouTubeDataApiCore()
+                                .AddAccessTokenProvider<TestAccessTokenProvider>()
+                                .AddVideos();
+                    }))
+            .Build();
+
+        await _host.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host is null)
+        {
+            return;
+        }
+
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+}
+
+public sealed class TestAccessTokenProvider : IAccessTokenProvider
+{
+    public Task<string?> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<string?>("test-access-token");
+}


### PR DESCRIPTION
## Description
This PR adds first-class support for the YouTube `videos` resource across service registration, request handling, and typed models.

### What changed
- Added `IVideosService` and `VideosService` with support for:
  - `ListByIdAsync`
  - `ListByChartAsync`
  - `ListByMyRatingAsync`
  - `InsertAsync`
  - `UpdateAsync`
  - `DeleteAsync`
  - `RateAsync`
  - `GetRatingAsync`
  - `ReportAbuseAsync`
- Added `IVideoHandler` and `VideoHandler` implementations for the corresponding REST endpoints.
- Added `VideoDefaults` endpoints for list/insert/update/delete/rate/getRating/reportAbuse.
- Added typed video models for response/request payloads, including content details/rating, file details, processing, player, statistics, status, topic details, suggestions, and related request/response DTOs.
- Added `VideoProperties` query/parameter container used by the handler/service layers.
- Updated DI registration:
  - Added `AddVideos()` / `AddVideos<TYouTubeVideos, THandler>()` to `YouTubeDataApiBuilder`
  - Registered videos by default in `AddYouTubeDataApi(...)`
- Updated JSON defaults to allow numeric fields represented as strings:
  - `JsonNumberHandling.AllowReadingFromString`

## Customer Impact
Consumers can now use strongly-typed videos APIs through this library instead of calling raw endpoints manually.  
Deserialization is more resilient for YouTube payloads that return numbers as strings.

## Regression?
Low risk. The change is mostly additive (new videos feature surface + registration).  
One cross-cutting behavior change exists in JSON number handling (string-to-number read support).

## Risk
Current non-success HTTP handling paths still throw placeholder exceptions (`NotImplementedException`) in videos handler/service flows.  
Follow-up improvement for standardized error mapping is recommended.

## Testing
Added tests:
- `VideoListResponseSerializationTests`
- `VideoPropertiesTests`
- `VideosServiceTests`

Coverage includes:
- Request method/path/query assertions
- Authorization header assertions
- Request body serialization checks
- Response deserialization checks
- Guard clause/argument validation checks

Local test execution in this environment was blocked by NuGet config access permissions:
- `dotnet test tests/Loonfactory.Google.Apis.YouTube.V3.Tests/Loonfactory.Google.Apis.YouTube.V3.Tests.csproj`
- Error: access denied to `C:\Users\loon\AppData\Roaming\NuGet\NuGet.Config`
